### PR TITLE
Added: link to Pre-Release sign up + instructions to enable Dev Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ First you'll need to install some tools on your machine. Please follow these ste
 Make sure you:
 * Sign up for [Spring '19 Pre-Release Developer Edition](https://www.salesforce.com/form/signup/prerelease-spring19.jsp) org
 * Enable Dev Hub in that Org
+    * From Setup, enter `dev` in the Quick Find box, then click **Dev Hub**. Ensure that **Enable Dev Hub** and **Enable Unlocked Packages** are enabled.
 * Install the SFDX CLI with the pre-release enabled.
 * Installed Visual Studio Code
     * While it is possible to use a different IDE/Editor, we will not be able to answer any questions regarding your set up and thus do not recommend doing so for this RPT

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ First you'll need to install some tools on your machine. Please follow these ste
 [Link to Trailhead instructions](https://trailhead.salesforce.com/content/learn/projects/set-up-your-lightning-web-components-developer-tools/install-development-tools?trail_id=build-lightning-web-components)
 
 Make sure you:
-* Sign up for pre-release Developer Edition org
+* Sign up for [Spring '19 Pre-Release Developer Edition](https://www.salesforce.com/form/signup/prerelease-spring19.jsp) org
 * Enable Dev Hub in that Org
 * Install the SFDX CLI with the pre-release enabled.
 * Installed Visual Studio Code


### PR DESCRIPTION
Changes
=====

-  Removed pre-release references from `README` since Spring '19 pre-release orgs are no longer available
-  Added instructions how to enable Dev Hub from 