### PR TITLE
Converte to settings from orgPreferences; orgPreferences is deprecated

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,7 +1,9 @@
 {
     "orgName": "scuevo Company",
     "edition": "Developer",
-    "orgPreferences" : {
-        "enabled": ["S1DesktopEnabled"]
+    "settings" : {
+        "orgPreferenceSettings": {
+            "s1DesktopEnabled": true
+        }
     }
 }


### PR DESCRIPTION
Changes
====

-  Converted `config/project-scratch-def.json` to use `settings` instead of `orgPreferences`.
    -  `orgPreferences` is deprecated in Spring '19